### PR TITLE
Reduce memory by using numpy array views

### DIFF
--- a/jax_sgmc/data/numpy_loader.py
+++ b/jax_sgmc/data/numpy_loader.py
@@ -49,7 +49,10 @@ class NumpyBase(DataLoader):
       if on_device:
         self._reference_data[name] = jnp.array(array, copy=copy)
       else:
-        self._reference_data[name] = onp.array(array, copy=copy)
+        if not isinstance(array, onp.ndarray) or copy:
+          self._reference_data[name] = onp.array(array, copy=True).view()
+        else:
+          self._reference_data[name] = array.view()
 
     # Check same number of observations
     if onp.any(onp.array(observation_counts) != observation_counts[0]):


### PR DESCRIPTION
It seems like the memory issue #26 can be improved by using an array view instead of the array itself.
